### PR TITLE
support PySimpleGui MENU_KEY_SEPARATOR

### DIFF
--- a/Demo_System_Tray_Menu_Item_Key.py
+++ b/Demo_System_Tray_Menu_Item_Key.py
@@ -1,0 +1,58 @@
+import PySimpleGUI as sg
+
+from psgtray import SystemTray
+
+
+def main():
+    layout = [
+        [
+            sg.Multiline(
+                size=(None, 20),
+                k='-OUTPUT-LOG-',
+                write_only=True,
+                auto_refresh=True,
+                reroute_cprint=True,
+            )
+        ],
+        [sg.Button('Clear'), sg.Push(), sg.Quit()],
+    ]
+    window = sg.Window(
+        'System Tray With Custom Menu Item Key',
+        layout=layout,
+        enable_close_attempted_event=True,
+    )
+
+    tray_menu = ['', ['Show Window', 'Hello::-HELLO-', '!Logs', '---', 'Quit']]
+    tray = SystemTray(
+        menu=tray_menu,
+        tooltip='System Tray With Custom Menu Item Key',
+        single_click_events=True,
+        window=window,
+    )
+
+    while True:
+        event, values = window.read()
+
+        if event == tray.key:
+            event = values[event]
+
+        if event in (sg.WIN_CLOSED, 'Quit'):
+            break
+
+        sg.cprint(f'event: {event}, values: {values}', colors='green on black')
+
+        if event == sg.WIN_CLOSE_ATTEMPTED_EVENT:
+            window.hide()
+        elif event in (sg.EVENT_SYSTEM_TRAY_ICON_ACTIVATED, '-SHOW-'):
+            window.un_hide()
+        elif event == 'Clear':
+            window['-OUTPUT-LOG-'].update('')
+        elif event == '-HELLO-':
+            sg.popup('Hello, Toy!', title='HELO')
+
+    tray.close()
+    window.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/psgtray/psgtray.py
+++ b/psgtray/psgtray.py
@@ -44,6 +44,7 @@ __version__ = '1.0.1'
     
     Copyright 2021 PySimpleGUI
 """
+MENU_ITEM_ATTR_KEY = 'psg_key'
 
 
 class SystemTray:
@@ -135,7 +136,8 @@ class SystemTray:
 
     # --------------------------- The methods below this point are not meant to be user callable ---------------------------
     def _on_clicked(self, icon, item: pystray.MenuItem):
-        self.window.write_event_value(self.key, item.text)
+        _val = getattr(item, MENU_ITEM_ATTR_KEY, item.text)
+        self.window.write_event_value(self.key, _val)
 
     def _convert_psg_menu_to_tray(self, psg_menu):
         menu_items = []
@@ -154,7 +156,16 @@ class SystemTray:
                         disabled = True
                         item = item[1:]
                     if not (item == pystray.Menu.SEPARATOR and sg.running_linux()):
-                        menu_items.append(pystray.MenuItem(item, self._on_clicked, enabled=not disabled, default=False))
+                        _key = None
+                        if isinstance(item, str):  # skip MenuItem object
+                            _name_key = item.split(sg.MENU_KEY_SEPARATOR, 1)
+                            if len(_name_key) == 2:
+                                item, _key = _name_key
+                        _menu_item = pystray.MenuItem(item, self._on_clicked, enabled=not disabled, default=False)
+                        if _key:
+                            setattr(_menu_item, MENU_ITEM_ATTR_KEY, _key)
+                        menu_items.append(_menu_item)
+
                 elif look_ahead != item:
                     if isinstance(look_ahead, list):
                         if menu_items is None:


### PR DESCRIPTION
Currently, the tray menu item (plain text) is only support limited PySimpleGui menu symbos (`!`, `---`), key seperator `::` was not allowed.

I add PySimpleGui MENU_KEY_SEPARATOR for tray menu, so we could use style as following:
```py
tray_menu = ['', ['Show Window', 'Hello::-HELLO-', '!Logs', '---', 'Quit']]
tray = SystemTray(
    menu=tray_menu,
    tooltip='System Tray With Custom Menu Item Key',
    single_click_events=True,
    window=window,
)
```

If we click tray menu item `Hello`, an event (value:  `-HELLO-`) will be thrown.