### PR TITLE
Catch NotImplementedError exception for tray_icon.notify

### DIFF
--- a/psgtray/psgtray.py
+++ b/psgtray/psgtray.py
@@ -124,8 +124,10 @@ class SystemTray:
         :param message: Main message to be displayed
         :type message: str
         """
-        #self.tray_icon.notify(title=str(title) if title is not None else '', message=str(message) if message is not None else '')
-        pass # Not working under X11/Linux
+        try:
+            self.tray_icon.notify(title=str(title) if title is not None else '', message=str(message) if message is not None else '')
+        except NotImplementedError:
+            pass # Not working under X11/Linux
     
     def close(self):
         """

--- a/psgtray/psgtray.py
+++ b/psgtray/psgtray.py
@@ -124,8 +124,9 @@ class SystemTray:
         :param message: Main message to be displayed
         :type message: str
         """
-        self.tray_icon.notify(title=str(title) if title is not None else '', message=str(message) if message is not None else '')
-
+        #self.tray_icon.notify(title=str(title) if title is not None else '', message=str(message) if message is not None else '')
+        pass # Not working under X11/Linux
+    
     def close(self):
         """
         Whlie not required, calling close will remove the icon from the tray right away.


### PR DESCRIPTION
Closes: #9

Catches the exception to prevent the mainloop from crashing. Doesn't actually patch the issue.